### PR TITLE
Fix import multisigaddress method on solo chain (#393)

### DIFF
--- a/neo-cli/Shell/MainService.cs
+++ b/neo-cli/Shell/MainService.cs
@@ -672,9 +672,9 @@ namespace Neo.Shell
         {
             if (NoWallet()) return true;
 
-            if (args.Length < 5)
+            if (args.Length < 4)
             {
-                Console.WriteLine("Error. Use at least 2 public keys to create a multisig address.");
+                Console.WriteLine("Error. Invalid parameters.");
                 return true;
             }
 


### PR DESCRIPTION
Don't need 5 elements for the command of import multisigaddress on solo chain.